### PR TITLE
Add "off" lightning manager (turns off all LEDS)

### DIFF
--- a/linux_thermaltake_rgb/lighting_manager.py
+++ b/linux_thermaltake_rgb/lighting_manager.py
@@ -229,6 +229,23 @@ class FullLightingEffect(ThermaltakeLightingEffect):
             device.set_lighting(mode=RGB.Mode.FULL, speed=0x00, values=values)
 
 
+class OffLightingEffect(ThermaltakeLightingEffect):
+    """
+    Turns off all LEDs.
+
+    Example config:
+    >>> lighting_manager:
+    >>>   model: 'off'
+
+    ::: settings: []
+    """
+    model = 'off'
+
+    def start(self):
+        for device in self._devices:
+            device.set_lighting(mode=RGB.Mode.FULL, speed=0x00, values=[0] * 3 * 12)
+
+
 class PerLEDLightingEffect(ThermaltakeLightingEffect):
     # TODO: per-led config
     # TODO: design a neat way to set this up via config (surely theres a better way then a massive array)


### PR DESCRIPTION
This just adds a more direct way to turn LEDs off instead of using `static`:
```
lighting_manager:
  model: 'off'
```