### PR TITLE
Simplify curve model by directly using numpy.interp.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setup(
         "GObject",
         "psutil",
         "pyusb",
-        "matplotlib",
-        "scipy",
         "numpy"
     ],
     entry_points="""


### PR DESCRIPTION
[numpy.interp](https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.interp.html) does exactly what we need, so dependency on scipy+matplotlib is unneeded.

Also made curve validation a little stricter (only allow monotonically
increasing curve, defined in the right order).