### PR TITLE
Systemd service changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,18 @@ If your's isn't listed, please create an issue and I'll implement it ASAP!!
 ### Pypi
 
 `sudo pip3 install linux_thermaltake_rgb`  
-The setup file will create the systemd user unit, and udev rule 
+The setup file will create the systemd unit
 in `/usr/share/linux_thermaltake_rgb`  
 you will need to copy these to the appropriate locations:
 
 ```bash
-sudo cp /usr/share/linux_thermaltake_rgb/90-linux_thermaltake_rgb.rules /etc/udev/rules.d/
-sudo cp /usr/share/linux_thermaltake_rgb/linux-thermaltake-rgb.service /usr/lib/systemd/user/
+sudo cp /usr/share/linux_thermaltake_rgb/linux-thermaltake-rgb.service /usr/lib/systemd/system/
 
 # and if this is a fresh install copy the default config file:
 sudo mkdir /etc/linux_thermaltake_rgb/
 sudo cp /usr/share/linux_thermaltake_rgb/config.yml /etc/linux_thermaltake_rgb/
 ```
 
-then add your user to the `plugdev` group - `sudo usermod -a -G plugdev $USER`  
-
-then reconnect your device.  
-  note: you may need to log out and back in so your user is recognised as being in the `plugdev` group  
-  
 ### Arch linux
 
 available in the aur as `linux-thermaltake-rgb`
@@ -45,7 +39,7 @@ available in the aur as `linux-thermaltake-rgb`
 ### starting and enabling the daemon
 
 start and enable the systemd service  
-`systemctl --user start linux-thermaltake-rgb.service; systemctl --user enable linux-thermaltake-rgb.service`  
+`systemctl enable --now linux-thermaltake-rgb.service`  
 
 
 ## Configuration

--- a/linux_thermaltake_rgb/assets/90-linux_thermaltake_rgb.rules
+++ b/linux_thermaltake_rgb/assets/90-linux_thermaltake_rgb.rules
@@ -1,2 +1,0 @@
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="264a", ATTRS{idProduct}=="1fa5", MODE="660", GROUP="plugdev"
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="264a", ATTRS{idProduct}=="2135", MODE="660", GROUP="plugdev"

--- a/linux_thermaltake_rgb/assets/linux-thermaltake-rgb.service
+++ b/linux_thermaltake_rgb/assets/linux-thermaltake-rgb.service
@@ -2,11 +2,32 @@
 AssertPathExists=/etc/linux_thermaltake_rgb/config.yml
 
 [Service]
-WorkingDirectory=/
-ExecStart=/bin/bash -c 'linux-thermaltake-rgb'
+EnvironmentFile=-/etc/default/linux-thermaltake-rgb
+
+ExecStart=/usr/bin/linux-thermaltake-rgb
+
 Restart=always
-PrivateTmp=true
-NoNewPrivileges=true
+RestartSec=5s
+
+CapabilityBoundingSet=
+NoNewPrivileges=yes
+PrivateUsers=true
+PrivateTmp=yes
+PrivateDevices=no
+DevicePolicy=closed
+DeviceAllow=char-usb_device
+ProtectSystem=strict
+ProtectHome=true
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=default.target

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         [console_scripts]
         linux-thermaltake-rgb=linux_thermaltake_rgb.daemon.main:main
     """,
-    data_files=[(DATA_FILE_LOCATION, ['linux_thermaltake_rgb/assets/90-linux_thermaltake_rgb.rules']),
-                (DATA_FILE_LOCATION, ['linux_thermaltake_rgb/assets/linux-thermaltake-rgb.service']),
+    data_files=[(DATA_FILE_LOCATION, ['linux_thermaltake_rgb/assets/linux-thermaltake-rgb.service']),
                 (DATA_FILE_LOCATION, ['linux_thermaltake_rgb/assets/config.yml'])]
 )


### PR DESCRIPTION
Here a set of proposed changes regarding the systemd service:

1. Change to a system instead of a user service. In the general case (single user machine) we want this service to run from boot to shutdown, not only on user session. Using a user service forces users to enable lingering to achieve that. This change also removes the need for specific udev rules / plugdev group.
2. Enable more hardening options.
3. Add support for optional `/etc/default/linux-thermaltake-rgb` file (can contain `DEBUG=true`).
4. Add delay between restarts.
5. Change back executable path to the default `/usr/bin`. It is downstream packagers job to adapt the service file if they don't deploy to the standard location.

Some of these might be controversial, so open for discussion ;)