### PR TITLE
fix wrong package requirement for GObject

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "pyyaml",
-        "GObject",
+        "PyGObject",
         "psutil",
         "pyusb",
         "numpy"


### PR DESCRIPTION
Currently the package is broken on Arch Linux, because of wrong requirement in `setup.py`:
```
Traceback (most recent call last):
  File "/usr/bin/linux-thermaltake-rgb", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3252, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'GObject' distribution was not found and is required by linux-thermaltake-rgb
```
This fixes it by referencing the correct package: https://pypi.org/project/PyGObject