### PR TITLE
fix deprecation warning by specifying yaml loader

### DIFF
--- a/linux_thermaltake_rgb/daemon/config.py
+++ b/linux_thermaltake_rgb/daemon/config.py
@@ -58,7 +58,7 @@ class Config:
 
         cfg = ''.join(cfg_lines)
         LOGGER.debug('raw config file\n** start **\n\n%s\n** end **\n', cfg)
-        return yaml.load(cfg)
+        return yaml.load(cfg, Loader=yaml.FullLoader)
 
     def parse_config(self, config):
             self.controllers = config.get('controllers')


### PR DESCRIPTION
Fixes this warning on conf loading:
```
linux-thermaltake-rgb[374647]: /usr/lib/python3.8/site-packages/linux_thermaltake_rgb/daemon/config.py:42: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation