### PR TITLE
Fixed missing 1 positional argument in daemon/config.py

### DIFF
--- a/linux_thermaltake_rgb/daemon/config.py
+++ b/linux_thermaltake_rgb/daemon/config.py
@@ -58,7 +58,7 @@ class Config:
 
         cfg = ''.join(cfg_lines)
         LOGGER.debug('raw config file\n** start **\n\n%s\n** end **\n', cfg)
-        return yaml.load(cfg)
+        return yaml.load(cfg, Loader=yaml.FullLoader)
 
     def parse_config(self, config):
             self.controllers = config.get('controllers')


### PR DESCRIPTION
For newer versions of python yaml, Simply loading the config with `yaml.load(cfg)` does not work due to it being deprecated, It has been fixed here.