### PR TITLE
Use safe_load() instead of load()

### DIFF
--- a/linux_thermaltake_rgb/daemon/config.py
+++ b/linux_thermaltake_rgb/daemon/config.py
@@ -58,7 +58,7 @@ class Config:
 
         cfg = ''.join(cfg_lines)
         LOGGER.debug('raw config file\n** start **\n\n%s\n** end **\n', cfg)
-        return yaml.load(cfg, Loader=yaml.FullLoader)
+        return yaml.safe_load(cfg)
 
     def parse_config(self, config):
             self.controllers = config.get('controllers')


### PR DESCRIPTION
I'd like to start off by saying I'm a little bit new to pull requests so I apologize in advance if any etiquette is being breached.

safe_load() would add the benefit of loading the YAML configuration without allowing for any circumstance where python objects could arbitrarily be loaded into it. It's a small change that does not, from what I can see, impact the function of this TTRGB daemon.

Alternatively, _yaml.full_load(cfg)_ could be used to reduce the number of arguments being passed here to just one.